### PR TITLE
Update node-flower-bridge (to squash bug)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "debug": "^2.2.0",
     "flower-power": ">=0.3.0",
     "flower-power-api": "^1.4.0",
-    "node-flower-bridge": "^1.7.2",
+    "node-flower-bridge": "^1.8.6",
     "promise": "^7.0.4"
   }
 }


### PR DESCRIPTION
Update node-flower-bridge to 1.8.6. Node flower bridge 1.7 has an old usb 1.2.0 dependencies and fails to download a certain file.
